### PR TITLE
fix created at default value to new date

### DIFF
--- a/src/lib/data/fetchers/todo.ts
+++ b/src/lib/data/fetchers/todo.ts
@@ -6,16 +6,10 @@ export class TodoFetcher {
 	static async getAll(fetchApi = fetch, depends?: (dep: string) => void) {
 		depends?.('app:todos');
 
-		const data = await FetchJson<Todo[]>({
+		return await FetchJson<Todo[]>({
 			url: '/api/todos',
 			fetchApi
 		});
-
-		return data.map((todo: Todo) => ({
-			...todo,
-			createdAt: new Date(todo.createdAt),
-			updatedAt: new Date(todo.updatedAt)
-		}));
 	}
 
 	static async insert(text: string, fetchApi = fetch) {

--- a/src/lib/data/schemas/todos.ts
+++ b/src/lib/data/schemas/todos.ts
@@ -1,4 +1,3 @@
-import { sql } from 'drizzle-orm';
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { v4 as uuid } from 'uuid';
 
@@ -8,7 +7,7 @@ export const TodosTable = sqliteTable('todos', {
 	completed: integer('completed', { mode: 'boolean' }).notNull().default(false),
 	createdAt: integer('created_at', { mode: 'timestamp' })
 		.notNull()
-		.default(sql`(current_timestamp)`),
+		.$defaultFn(() => new Date()),
 	updatedAt: integer('updated_at', { mode: 'timestamp' })
 		.notNull()
 		.$onUpdateFn(() => new Date())


### PR DESCRIPTION
Using sql`(current_timestamp)` will result in date time string in the db. This is not a number type, and will caused error.

![image](https://github.com/sky3742/svelte-flowbite-boilerplate/assets/23443034/27ab7830-7c11-4e6d-b2f9-46243d509d54)

Notice, it should be the same as "updated at" column